### PR TITLE
Allow PrivateNetworkOnlyFlag option

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,8 @@ The reference of available configuration options is listed below.
  * `ssh_timeout` (string) - The time to wait for SSH to become available before timing out. The format of this value is a duration such as "5s" or "5m". The default SSH timeout is "1m". Defaults to "15m"
  * `ssh_private_key_file` (string) - Use this ssh private key file instead of a generated ssh key pair for connecting to the instance.
  * `instance_state_timeout` (string) - The time to wait, as a duration string, for an instance or image snapshot to enter a desired state (such as "active") before timing out. The default state timeout is "25m"
+ * `private_network_only_flag` (bool) - Specifies whether or not the instance only has access to the private network. When true this flag specifies that a compute instance is to only have access to the private network. Defaults to false.
+
 
 As already stated above, a good way of reviewing the available options is by inspecting the output of the following API call:
 

--- a/builder/softlayer/builder.go
+++ b/builder/softlayer/builder.go
@@ -21,24 +21,25 @@ type Config struct {
 	common.PackerConfig `mapstructure:",squash"`
 	Comm                communicator.Config `mapstructure:",squash"`
 
-	Username         string `mapstructure:"username"`
-	APIKey           string `mapstructure:"api_key"`
-	DatacenterName   string `mapstructure:"datacenter_name"`
-	ImageName        string `mapstructure:"image_name"`
-	ImageDescription string `mapstructure:"image_description"`
-	ImageType        string `mapstructure:"image_type"`
-	BaseImageId      string `mapstructure:"base_image_id"`
-	BaseOsCode       string `mapstructure:"base_os_code"`
+	Username               string `mapstructure:"username"`
+	APIKey                 string `mapstructure:"api_key"`
+	DatacenterName         string `mapstructure:"datacenter_name"`
+	ImageName              string `mapstructure:"image_name"`
+	ImageDescription       string `mapstructure:"image_description"`
+	ImageType              string `mapstructure:"image_type"`
+	BaseImageId            string `mapstructure:"base_image_id"`
+	BaseOsCode             string `mapstructure:"base_os_code"`
+	PrivateNetworkOnlyFlag bool   `mapstructure:"private_network_only_flag"`
 
-	InstanceName         string `mapstructure:"instance_name"`
-	InstanceDomain       string `mapstructure:"instance_domain"`
-	InstanceCpu          int    `mapstructure:"instance_cpu"`
-	InstanceMemory       int64  `mapstructure:"instance_memory"`
-	InstanceNetworkSpeed int    `mapstructure:"instance_network_speed"`
-	InstanceDiskCapacity int    `mapstructure:"instance_disk_capacity"`
+	InstanceName           string `mapstructure:"instance_name"`
+	InstanceDomain         string `mapstructure:"instance_domain"`
+	InstanceCpu            int    `mapstructure:"instance_cpu"`
+	InstanceMemory         int64  `mapstructure:"instance_memory"`
+	InstanceNetworkSpeed   int    `mapstructure:"instance_network_speed"`
+	InstanceDiskCapacity   int    `mapstructure:"instance_disk_capacity"`
 
-	RawStateTimeout string `mapstructure:"instance_state_timeout"`
-	StateTimeout    time.Duration
+	RawStateTimeout        string `mapstructure:"instance_state_timeout"`
+	StateTimeout           time.Duration
 
 	ctx interpolate.Context
 }

--- a/builder/softlayer/client.go
+++ b/builder/softlayer/client.go
@@ -30,18 +30,19 @@ type SoftLayerRequest struct {
 
 // Based on: http://sldn.softlayer.com/reference/datatypes/SoftLayer_Container_Virtual_Guest_Configuration/
 type InstanceType struct {
-	HostName             string `json:"hostname"`
-	Domain               string
-	Datacenter           string
-	Cpus                 int
-	Memory               int64
-	HourlyBillingFlag    bool
-	LocalDiskFlag        bool
-	DiskCapacity         int
-	NetworkSpeed         int
-	ProvisioningSshKeyId int64
-	BaseImageId          string
-	BaseOsCode           string
+	HostName               string `json:"hostname"`
+	Domain                 string
+	Datacenter             string
+	Cpus                   int
+	Memory                 int64
+	HourlyBillingFlag      bool
+	LocalDiskFlag          bool
+	PrivateNetworkOnlyFlag bool
+	DiskCapacity           int
+	NetworkSpeed           int
+	ProvisioningSshKeyId   int64
+	BaseImageId            string
+	BaseOsCode             string
 }
 
 type InstanceReq struct {
@@ -52,6 +53,7 @@ type InstanceReq struct {
 	Memory                   int64                     `json:"maxMemory"`
 	HourlyBillingFlag        bool                      `json:"hourlyBillingFlag"`
 	LocalDiskFlag            bool                      `json:"localDiskFlag"`
+	PrivateNetworkOnlyFlag   bool                      `json:"privateNetworkOnlyFlag"`
 	NetworkComponents        []*NetworkComponent       `json:"networkComponents"`
 	BlockDeviceTemplateGroup *BlockDeviceTemplateGroup `json:"blockDeviceTemplateGroup,omitempty"`
 	BlockDevices             []*BlockDevice            `json:"blockDevices,omitempty"`
@@ -195,7 +197,7 @@ func (self SoftlayerClient) doHttpRequest(path string, requestType string, reque
 		return []interface{} {v,}, nil
 
 	case nil:
-		return []interface{} {nil,}, nil	
+		return []interface{} {nil,}, nil
 	default:
 		return nil, errors.New("Unexpected type in HTTP response")
 	}
@@ -221,6 +223,7 @@ func (self SoftlayerClient) CreateInstance(instance InstanceType) (map[string]in
 		Cpus:              instance.Cpus,
 		Memory:            instance.Memory,
 		HourlyBillingFlag: true,
+		PrivateNetworkOnlyFlag: instance.PrivateNetworkOnlyFlag,
 		LocalDiskFlag:     false,
 		NetworkComponents: []*NetworkComponent{
 			&NetworkComponent{
@@ -310,6 +313,18 @@ func (self SoftlayerClient) DestroySshKey(keyId int64) error {
 
 func (self SoftlayerClient) getInstancePublicIp(instanceId string) (string, error) {
 	response, err := self.doRawHttpRequest(fmt.Sprintf("SoftLayer_Virtual_Guest/%s/getPrimaryIpAddress.json", instanceId), "GET", nil)
+	if err != nil {
+		return "", nil
+	}
+
+	var validIp = regexp.MustCompile(`[0-9]{1,4}\.[0-9]{1,4}\.[0-9]{1,4}\.[0-9]{1,4}`)
+	ipAddress := validIp.Find(response)
+
+	return string(ipAddress), nil
+}
+
+func (self SoftlayerClient) getInstancePrivateIp(instanceId string) (string, error) {
+	response, err := self.doRawHttpRequest(fmt.Sprintf("SoftLayer_Virtual_Guest/%s/getPrimaryBackendIpAddress.json", instanceId), "GET", nil)
 	if err != nil {
 		return "", nil
 	}

--- a/builder/softlayer/ssh.go
+++ b/builder/softlayer/ssh.go
@@ -11,7 +11,15 @@ func commHost(state multistep.StateBag) (string, error) {
 	client := state.Get("client").(*SoftlayerClient)
 	instance := state.Get("instance_data").(map[string]interface{})
 	instanceId := instance["globalIdentifier"].(string)
-	ipAddress, err := client.getInstancePublicIp(instanceId)
+	config := state.Get("config").(Config)
+	privateNetworkFlag := config.PrivateNetworkOnlyFlag
+	var ipAddress string
+	var err error
+	if privateNetworkFlag == true {
+		ipAddress, err = client.getInstancePrivateIp(instanceId)
+	} else {
+		ipAddress, err = client.getInstancePublicIp(instanceId)
+	}
 	if err != nil {
 		err := errors.New(fmt.Sprintf("Failed to fetch Public IP address for instance '%s'", instanceId))
 		return "", err

--- a/builder/softlayer/step_create_instance.go
+++ b/builder/softlayer/step_create_instance.go
@@ -31,6 +31,7 @@ func (self *stepCreateInstance) Run(state multistep.StateBag) multistep.StepActi
 		Memory:               config.InstanceMemory,
 		HourlyBillingFlag:    true,
 		LocalDiskFlag:        true,
+		PrivateNetworkOnlyFlag: config.PrivateNetworkOnlyFlag,
 		DiskCapacity:         config.InstanceDiskCapacity,
 		NetworkSpeed:         config.InstanceNetworkSpeed,
 		ProvisioningSshKeyId: ProvisioningSshKeyId,


### PR DESCRIPTION
This commit adds the option in softlayer packer
plugin to set up an instance with private only
network.
Allows to specify private_network_only_flag parameter,
when set to true, the instance spun up will only
have a private ip. And it will try to ssh and run the
scripts using this private ip.
