### PR TITLE
added a condition to skip metadata device from image capturing

### DIFF
--- a/builder/softlayer/client.go
+++ b/builder/softlayer/client.go
@@ -361,7 +361,9 @@ func (self SoftlayerClient) findNonSwapBlockDeviceIds(blockDevices []interface{}
 		name := diskImage["name"].(string)
 		id := int64(blockDevice["id"].(float64))
 
-		if !strings.Contains(name, "SWAP") {
+		// Skip both SWAP and METADATA devices
+		// Reference - https://github.com/softlayer/softlayer-python/pull/776
+		if ( !strings.Contains(name, "SWAP") && !strings.Contains(name, "METADATA") ) {
 			blockDeviceIds[deviceCount] = id
 			deviceCount++
 		}

--- a/script/test
+++ b/script/test
@@ -9,6 +9,6 @@ header "Tests"
 go test $(glide novendor)
 
 header "Linter"
-gometalinter --deadline=1m --vendored-linters --vendor --disable=gotype
+gometalinter --deadline=2m --vendored-linters --vendor --disable=gotype
 
 # vim: set ft=sh :


### PR DESCRIPTION
Changed the **findNonSwapBlockDeviceIds** to exclude both swap and metadata devices. As both are not used for image capturing.