### PR TITLE
remove ssh_private_key_file constraint

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,6 @@ The reference of available configuration options is listed below.
  * `api_key` (string) - The api key defined for the chosen user name. You can find what is your api key at the account->users tab of the SoftLayer web console. If unspecified, the value is taken from the SOFTLAYER_API_KEY environment variable.
  * `image_name` (string) - The name of the resulting image that will appear in your account. This must be unique. To help make this unique, use a function like timestamp.
  * `base_image_id` (string) - The ID of the base image to use (usually defined by the `globalIdentifier` or the `uuid` fields in SoftLayer API). This is the image that will be used for launching a new instance.
- __NOTE__ that if you choose to use this option, you must specify a private key using `ssh_private_key_file` (described below).
  To view all of your currently available images, run:
 
 ```SHELL

--- a/builder/softlayer/builder.go
+++ b/builder/softlayer/builder.go
@@ -155,12 +155,6 @@ func (self *Builder) Prepare(raws ...interface{}) (parms []string, retErr error)
 			errs, errors.New("please specify only one of base_image_id or base_os_code"))
 	}
 
-	if self.config.BaseImageId != "" && self.config.Comm.SSHPrivateKey == "" {
-		errs = packer.MultiErrorAppend(
-			errs, errors.New("when using base_image_id, you must specify ssh_private_key_file "+
-				"since automatic ssh key config for custom images isn't supported by SoftLayer API"))
-	}
-
 	stateTimeout, err := time.ParseDuration(self.config.RawStateTimeout)
 	if err != nil {
 		errs = packer.MultiErrorAppend(


### PR DESCRIPTION
There's no mention of this constraint in the SoftLayer API docs.  I tested this manually after removing the constraint and packer was able to create a temporary ssh key when using a base image id.

https://sldn.softlayer.com/reference/services/softlayer_virtual_guest/createObject